### PR TITLE
フロントに流すリクエストはIngressのデフォルトの配送先として指定する

### DIFF
--- a/manifests/10_qicoo-api/14_ingress/qicoo-ingress.yaml
+++ b/manifests/10_qicoo-api/14_ingress/qicoo-ingress.yaml
@@ -17,14 +17,13 @@ metadata:
     kubernetes.io/ingress.allow-http: "false"
     networking.gke.io/managed-certificates: qicoo-tls-cert
 spec:
+  backend:
+    serviceName: qicoo-front
+    servicePort: 37000
   rules:
   - http:
       paths:
       - path: /api/v1/*
         backend:
           serviceName: qicoo-api
-          servicePort: 37000
-      - path: /*
-        backend:
-          serviceName: qicoo-front
           servicePort: 37000


### PR DESCRIPTION
開発デーの最後に入れた修正をPushしてなかったので。